### PR TITLE
NSKOPS-179 add the deb package task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 *.sublime-workspace
 .project
 node_modules
+./.tmp
+output

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -95,7 +95,44 @@ module.exports = function(grunt) {
 					keepalive: true
 				}
 			}
-		}
+		},
+//deb package
+	deb_package: {
+	  options: {
+            maintainer: "Konstantin Tushakov ktu@tradeshift.com",
+            version: "2.0.0",
+            name: "elasticsearch-head",
+            short_description: "Head plugin for elasticsearch",
+            long_description: "Debian package for the elasticsearch head plugin",
+            target_architecture: "all",
+            category: "devel",
+            build_number: "1",
+            dependencies: [ "elasticsearch (>=2.0.0)" ],           // List of the package dependencies
+            tmp_dir: './.tmp/',            // The task working dir
+            output: './output/'         // Where your .deb should be created
+            },
+            build: {
+                    files: [{
+                        cwd: './_site',
+                        src: '**/*',
+                        dest: '/usr/share/elasticsearch/plugins/head/_site'
+                    },
+                    {
+                        cwd: './src/',
+                        src: '**/*',
+                        dest: '/usr/share/elasticsearch/plugins/head/src/'
+                    },
+                    {
+                        cwd: './test/',
+                        src: '**/*',
+                        dest: '/usr/share/elasticsearch/plugins/head/test/'
+                    },
+                    {
+                        src: ['plugin-descriptor.properties', 'README.textile', 'index.html'],
+                        dest: '/usr/share/elasticsearch/plugins/head/'
+                    }],
+            }
+        }
 
 	});
 
@@ -105,11 +142,12 @@ module.exports = function(grunt) {
 	grunt.loadNpmTasks('grunt-contrib-connect');
 	grunt.loadNpmTasks('grunt-contrib-copy');
 	grunt.loadNpmTasks('grunt-contrib-jasmine');
+	grunt.loadNpmTasks('grunt-deb');
 
 	// Default task(s).
 	grunt.registerTask('default', ['clean', 'concat', 'copy', 'jasmine']);
 	grunt.registerTask('server', ['connect:server']);
 	grunt.registerTask('dev', [ 'default', 'watch' ]);
-
+	grunt.registerTask('debian_package', ['deb_package']);
 
 };

--- a/README.textile
+++ b/README.textile
@@ -93,3 +93,8 @@ To contribute an internationalisation
 # Submit a pull request
 
 !http://mobz.github.com/elasticsearch-head/screenshots/clusterOverview.png(ClusterOverview Screenshot)!
+
+h4. Deb package build
+
+@grunt debian_package@
+The compiled debian package of elasticsearch-head will be placed to ./output


### PR DESCRIPTION
This PR allows to create deb package elasticsearch-head plugin for ES-2.x.x versions. 
@sorenmat