### PR TITLE
NSKOPS-246 added build steps

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -96,5 +96,15 @@ To contribute an internationalisation
 
 h4. Deb package build
 
-@grunt debian_package@
-The compiled debian package of elasticsearch-head will be placed to ./output
+For a building of the package was used a docker image ubuntu:latest.
+All actions was done under root.
+
+@apt-get update \@
+@&& apt-get install -y git nodejs npm && ln -s /usr/bin/nodejs /usr/bin/node \@
+@&& git clone https://github.com/Tradeshift/elasticsearch-head.git \@
+@&& cd elasticsearch-head && git checkout deb-es2 && npm install \@
+@&& ./node_modules/grunt-cli/bin/grunt debian_package && ls -l output@
+
+@cd ./output@
+
+@scp elasticsearch-head_current_version_all.deb your_user_name@@@your_host_ip:/path-to-directory@

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "grunt-contrib-clean": "0.5.0",
     "grunt-contrib-jasmine": "0.6.4",
     "karma": "0.12.16",
-    "grunt-karma": "0.8.3"
+    "grunt-karma": "0.8.3",
+    "grunt-deb": "0.2.3",
+    "grunt-cli": "1.1.0"
   }
 }


### PR DESCRIPTION
In the PR added build steps. 
A testing of clean building of deb package was done using the ubuntu docker images (ubuntu:latest, phusion/baseimage:latest). 
Before PR is not merged into Tradeshift repositories in an instruction need to use
https://github.com/ghostik/elasticsearch-head.git 
instead 
https://github.com/Tradeshift/elasticsearch-head.git.
@mkostrikin please review.